### PR TITLE
Add Linux and Unix Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,10 +4,16 @@ project(mu-edit)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/../bin)
 
-add_subdirectory(PDCurses)
-add_compile_options(
-	-std=c++17
-)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(WIN32 OR MSVC)
+	add_subdirectory(PDCurses)
+	set(CURSES_LIBRARY PDcurses)
+else()
+	find_package(Curses REQUIRED)
+	include_directories(${CURSES_INCLUDE_DIR})
+endif()
 
 add_executable(
 	mu-edit
@@ -16,5 +22,5 @@ add_executable(
 
 target_link_libraries(
 	mu-edit
-	PDcurses
+	${CURSES_LIBRARY}
 )


### PR DESCRIPTION
Add Linux and Unix Support by substituting PDCurses with the native curses package whenever the target isn't WIN32 or MSVC.